### PR TITLE
Fix broken dependencies

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm install ; npm run build"
+  command = "npm install gulp@^3.9.1 ; npm install ; npm rebuild node-sass ; npm run build"
   publish = "dist"
   environment = { NODE_VERSION = "11.15.0" }
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
 [build]
-  command = "npm run build"
+  command = "npm install ; npm run build"
   publish = "dist"
+  environment = { NODE_VERSION = "11.15.0" }
 
 [context.deploy-preview]
   command = "npm run build-preview"


### PR DESCRIPTION
Tried originally enforcing graceful-fs version via https://stackoverflow.com/a/60921145 but that did not work, so ended up enforcing node version. Fixes https://github.com/bdougie/casper-cms-template/issues/6